### PR TITLE
Remove divide-by-zero in bio

### DIFF
--- a/docs/jeffreyerikson.md
+++ b/docs/jeffreyerikson.md
@@ -1,3 +1,2 @@
 # Jeffrey Erikson Bio
 - Name: Jeffrey Erikson
-- x = x / 0


### PR DESCRIPTION
Divide by zero errors are no good, @wittmer85 !  Removing it.
